### PR TITLE
Fix package discovery issue.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "rootinc\\LaravelAzureMiddleware\\AzureServiceProvider"
+                "RootInc\\LaravelAzureMiddleware\\AzureServiceProvider"
             ]
         }
     }

--- a/src/AzureServiceProvider.php
+++ b/src/AzureServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace rootinc\LaravelAzureMiddleware;
+namespace RootInc\LaravelAzureMiddleware;
 
 use Illuminate\Support\ServiceProvider;
 


### PR DESCRIPTION
Due to the namespace and autoload containing capitals, having RootInc in lowercase within the new class and the composer JSON breaks artisan

Signed-off-by: Thimo Braker <thibmorozier@live.nl>