### PR TITLE
Fix unmanaged exception when Azure response contents are missing

### DIFF
--- a/src/Azure.php
+++ b/src/Azure.php
@@ -61,6 +61,10 @@ class Azure
             $this->fail($request, $e);
         }
 
+        if (empty($contents->access_token) || empty($contents->refresh_token)) {
+            $this->fail($request, \Exception('Missing tokens in response contents'));
+        }
+        
         $request->session()->put('_rootinc_azure_access_token', $contents->access_token);
         $request->session()->put('_rootinc_azure_refresh_token', $contents->refresh_token);
 
@@ -177,10 +181,10 @@ class Azure
      * Handler that is called when a failed handshake has taken place
      *
      * @param \Illuminate\Http\Request $request
-     * @param \GuzzleHttp\Exception\RequestException $e
+     * @param \Exception $e
      * @return string
      */
-    protected function fail(Request $request, RequestException $e)
+    protected function fail(Request $request, \Exception $e)
     {
         // Added by smitthhyy 18Dec2019 - Return 403 if user authenticates in AD but is not assigned to this application
         if ($request->isMethod('get')) {


### PR DESCRIPTION
Checking our laravel log, most of errors come from an unmanaged exception from Azure login:

"Undefined variable: contents at .../vendor/rootinc/laravel-azure-middleware/src/Azure.php:64"

Problem:
In some cases the tokens are not defined in the service response. This is not specifically an HTTP issue, so Guzzle client throwns no exceptions. But, since the tokens are not checked before use, an unmanaged exception is thrown.

Solution:
Check tokens existance and invoke fail() method when tokens are missing.