### PR TITLE
Fix post-login redirection to intended URL

### DIFF
--- a/src/Azure.php
+++ b/src/Azure.php
@@ -121,7 +121,7 @@ class Azure
      */
     protected function redirect(Request $request)
     {
-        return redirect($this->login_route);
+        return redirect()->guest($this->login_route);
     }
 
     /**


### PR DESCRIPTION
Fix post-login redirection to the intended URL. By using `Redirector::guest`, the current URL will be put in the session before redirection to Azure (session key: `url.intended`). Then, the existing `intended` call in the `success` method redirects to the intended URL as expected.