### PR TITLE
Added redirect_uri to form_parms in Azure.php. This fixes the 400 Bad…

### DIFF
--- a/src/Azure.php
+++ b/src/Azure.php
@@ -154,6 +154,7 @@ class Azure
                     'client_secret' => config('azure.client.secret'),
                     'code' => $code,
                     'resource' => config('azure.resource'),
+                    'redirect_uri' => route('azure.callback'),
                 ]
             ]);
 


### PR DESCRIPTION
When trying to provide an redirect url to prams, error comes back:

`Client error: `POST https://login.microsoftonline.com/47e303e7-e5fa-4519-a069-28a5a61c57d8/oauth2/token` resulted in a `400 Bad Request` response:{"error":"invalid_grant","error_description":"AADSTS700009: Reply address must be provided when presenting an authorizat (truncated...)`

This is because the form_parms need a redirect uri. Added that to make sure the error no longer occur.