### PR TITLE
allow redirect_uri param also for initial authentication

### DIFF
--- a/src/Azure.php
+++ b/src/Azure.php
@@ -147,14 +147,20 @@ class Azure
         $code = $request->input('code');
 
         try {
+            $form_params = [
+                'grant_type' => 'authorization_code',
+                'client_id' => config('azure.client.id'),
+                'client_secret' => config('azure.client.secret'),
+                'code' => $code,
+                'resource' => config('azure.resource'),
+            ];
+
+            if (Route::has('azure.callback')) {
+                $form_params['redirect_uri'] = route('azure.callback');
+            }
+
             $response = $client->request('POST', $this->baseUrl . config('azure.tenant_id') . $this->route . "token", [
-                'form_params' => [
-                    'grant_type' => 'authorization_code',
-                    'client_id' => config('azure.client.id'),
-                    'client_secret' => config('azure.client.secret'),
-                    'code' => $code,
-                    'resource' => config('azure.resource'),
-                ]
+                'form_params' => $form_params,
             ]);
 
             $contents = json_decode($response->getBody()->getContents());


### PR DESCRIPTION
Dynamically add redirect_uri parameter also for initial login. There already is the same feature on the `handle()` method which works as middleware on all protected routes. But when user is initially sent to Azure to authenticate, the redirect_uri parameter is still missing. This PR aims to fix it.